### PR TITLE
support trimming of paired end reads by interleave -> trim -> re-pair

### DIFF
--- a/seqtk.c
+++ b/seqtk.c
@@ -227,7 +227,7 @@ int stk_pairfq(int argc, char *argv[]){
     }
     fprintf(stderr, "seqtk: dropped %d singletons\n", skipped);
 	kseq_destroy(seq1);
-    free(seq2->seq.s); free(seq2->qual.s); free(seq2->name.s);
+    free(seq2->seq.s); free(seq2->qual.s); free(seq2->name.s); free(seq2);
 	gzclose(fp);
     return 0;
 }


### PR DESCRIPTION
This set of commits allows something like:

``` shell

./seqtk interleave R1.fastq R2.fastq \
   | ./seqtk trimfq  - \
   | ./seqtk pairfq -  

```

So that the existing machinery can be used to trim paired-end fastq files. Or **any single-end trim command can be used in place of `seqtk trimfq`**

This can be checked by appending this to the end:

```
| awk 'NR % 4 == 1 { print $1 }' | uniq -c | awk '$1 != 2'
```

which should give empty output when all reads are paired.

It would be nice of the cpy_kseq command was included in kseq.h 
