### PR TITLE
fixes occasional issue when reading from pipes

### DIFF
--- a/kseq.h
+++ b/kseq.h
@@ -70,8 +70,10 @@
 		if (ks->begin >= ks->end) { \
 			ks->begin = 0; \
 			ks->end = __read(ks->f, ks->buf, ks->bufsize); \
-			if (ks->end < ks->bufsize) ks->is_eof = 1; \
-			if (ks->end == 0) return -1; \
+			if (ks->end == 0) { \
+				ks->is_eof = 1; \
+				return -1; \
+			} \
 		} \
 		return (int)ks->buf[ks->begin++]; \
 	} \
@@ -102,8 +104,9 @@ typedef struct __kstring_t {
 				if (!ks->is_eof) { \
 					ks->begin = 0; \
 					ks->end = __read(ks->f, ks->buf, ks->bufsize); \
-					if (ks->end < ks->bufsize) ks->is_eof = 1; \
-					if (ks->end == 0) break; \
+					if (ks->end == 0){ \
+						ks->is_eof = 1; \
+					} break; \
 				} else break; \
 			} \
 			if (delimiter == KS_SEP_LINE) {  \


### PR DESCRIPTION
When reading from a pipe such as `stdin`, the amount of bytes read may be smaller than the size of the buffer. In these cases continue as usual and only break if EOF is encountered (indicated by zero read bytes).
