### PR TITLE
clarify licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License
-Copyright (c) 20082-2012 by Heng Li <lh3@me.com>
+Copyright (c) 2008-2012 by Heng Li <lh3@me.com>
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including

--- a/README.md
+++ b/README.md
@@ -54,3 +54,6 @@ Seqtk Examples
 
         seqtk trimfq -b 5 -e 10 in.fa > out.fa
 
+License
+-------
+Seqtk is released under an MIT license. See LICENSE for further details.

--- a/seqtk.c
+++ b/seqtk.c
@@ -1,6 +1,6 @@
 /* The MIT License
 
-   Copyright (c) 20082-2012 by Heng Li <lh3@me.com>
+   Copyright (c) 2008-2012 by Heng Li <lh3@me.com>
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the


### PR DESCRIPTION
Hi,

Just crossing some Ts here.

`ksw.h` and `trimadap.c` seem to be lacking licensing at the top too, unsure if this is intentional.