### PR TITLE
Cleanup Makefile to respect users environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-CC=gcc
-CFLAGS=-g -Wall -O2 -Wno-unused-function
-BINDIR=/usr/local/bin
+CC ?= gcc
+CFLAGS ?= -g -Wall -O2 -Wno-unused-function
+PREFIX ?= /usr/local
+BINDIR ?= $(DESTDIR)$(PREFIX)/bin
+INSTALL ?= install
+MKDIR ?= mkdir
 
 all:seqtk
 
@@ -8,7 +11,8 @@ seqtk:seqtk.c khash.h kseq.h
 		$(CC) $(CFLAGS) seqtk.c -o $@ -lz -lm
 
 install:all
-		install seqtk $(BINDIR)
+		$(MKDIR) -p $(BINDIR)
+		$(INSTALL) seqtk $(BINDIR)
 
 clean:
 		rm -fr gmon.out *.o ext/*.o a.out seqtk trimadap *~ *.a *.dSYM session*


### PR DESCRIPTION
Respect variables already defined and support temporary path $(DESTDIR)
to install into.