### PR TITLE
Update Makefile to play nice with bioconda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINDIR=/usr/local/bin
 all:seqtk
 
 seqtk:seqtk.c khash.h kseq.h
-		$(CC) $(CFLAGS) seqtk.c -o $@ -lz -lm
+		$(CC) $(CFLAGS) seqtk.c -o $@ $(LDFLAGS) -lz -lm
 
 install:all
 		install seqtk $(BINDIR)


### PR DESCRIPTION
Bioconda now setups up a number of environment variables to correctly compile code on different platforms. To play nicely, and compile correctly, the Makefile should make use the LDFLAGS environmental var.