### PR TITLE
Have cutN report N:s also at beginning of sequence

### DIFF
--- a/seqtk.c
+++ b/seqtk.c
@@ -1041,10 +1041,8 @@ int stk_cutN(int argc, char *argv[])
 	while ((l = kseq_read(ks)) >= 0) {
 		int k = 0, begin = 0, end = 0;
 		while (find_next_cut(ks, k, &begin, &end) >= 0) {
-			if (begin != 0) {
-				if (gap_only) printf("%s\t%d\t%d\n", ks->name.s, begin, end);
-				else print_seq(stdout, ks, k, begin);
-			}
+			if (gap_only) printf("%s\t%d\t%d\n", ks->name.s, begin, end);
+			else print_seq(stdout, ks, k, begin);
 			k = end;
 		}
 		if (!gap_only) print_seq(stdout, ks, k, l);


### PR DESCRIPTION
Fixes a possible bug or changes function of cutN such that it will report all 'N' regions, including the ones at the beginning of sequence.  Testing status: "works for me"