### PR TITLE
seqtk_telomere_reads_output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ Seqtk Examples
 * Find telomere (TTAGGG)n repeats:
 
         seqtk telo seq.fa > telo.bed 2> telo.count
+        In this folk, the origin sequences will be output

--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ Seqtk Examples
 
 * Find telomere (TTAGGG)n repeats:
 
-        seqtk telo seq.fa > telo.bed 2> telo.count
+        seqtk telo seq.fa > telo.fasta
         In this folk, the origin sequences will be output

--- a/seqtk.c
+++ b/seqtk.c
@@ -2012,6 +2012,8 @@ int stk_telo(int argc, char *argv[])
 		if (max >= min_score) {
 			if (!show_profile) printf(">%s\t0\t%ld\t%ld\n", seq->name.s, max_i + 1, seq->seq.l);
 			printf("%s\n", seq->seq.s);
+			if (!show_profile) printf(">%s_remove\t%ld\t%ld\t%ld\n", seq->name.s, max_i, seq->seq.l, seq->seq.l);
+			printf("%s\n", seq->seq.s + max_i + 1);
 			sum_telo += max_i + 1;
 			st = max_i + 1;
 		}
@@ -2030,7 +2032,12 @@ int stk_telo(int argc, char *argv[])
 		}
 		if (max >= min_score) {
 			if (!show_profile) printf(">%s\t%ld\t%ld\t%ld\n", seq->name.s, max_i, seq->seq.l, seq->seq.l);
-			printf("%s\n", seq->seq.s); 
+			printf("%s\n", seq->seq.s);
+			if (!show_profile) printf(">%s_remove\t%ld\t%ld\t%ld\n", seq->name.s, max_i, seq->seq.l, seq->seq.l);
+			char temp_char = seq->seq.s[max_i];
+			seq->seq.s[max_i] = '\0';
+			printf("%s\n", seq->seq.s);
+			seq->seq.s[max_i] = temp_char;
 			sum_telo += seq->seq.l - max_i;
 		}
 	}

--- a/seqtk.c
+++ b/seqtk.c
@@ -2010,7 +2010,8 @@ int stk_telo(int argc, char *argv[])
 			else if (max - score > max_drop) break;
 		}
 		if (max >= min_score) {
-			if (!show_profile) printf("%s\t0\t%ld\t%ld\n", seq->name.s, max_i + 1, seq->seq.l);
+			if (!show_profile) printf(">%s\t0\t%ld\t%ld\n", seq->name.s, max_i + 1, seq->seq.l);
+			printf("%s\n", seq->seq.s);
 			sum_telo += max_i + 1;
 			st = max_i + 1;
 		}
@@ -2028,7 +2029,8 @@ int stk_telo(int argc, char *argv[])
 			else if (max - score > max_drop) break;
 		}
 		if (max >= min_score) {
-			if (!show_profile) printf("%s\t%ld\t%ld\t%ld\n", seq->name.s, max_i, seq->seq.l, seq->seq.l);
+			if (!show_profile) printf(">%s\t%ld\t%ld\t%ld\n", seq->name.s, max_i, seq->seq.l, seq->seq.l);
+			printf("%s\n", seq->seq.s); 
 			sum_telo += seq->seq.l - max_i;
 		}
 	}


### PR DESCRIPTION
In the original seqtk telo, it only outputs the sequence ID and the telomere coordinates. I modified it because I needed to extract both the original sequence and the corresponding telomere-removed sequence (to avoid the influence of the telomere sequence on alignments).